### PR TITLE
update font awesome css to 4.7.0

### DIFF
--- a/folium/folium.py
+++ b/folium/folium.py
@@ -43,7 +43,7 @@ _default_css = [
     ('bootstrap_theme_css',
      'https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css'),  # noqa
     ('awesome_markers_font_css',
-     'https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css'),  # noqa
+     'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css'),  # noqa
     ('awesome_markers_css',
      'https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css'),  # noqa
     ('awesome_rotate_css',


### PR DESCRIPTION
~ 50 new icons were added from 4.6.3 to 4.7, since leaflet.awesome-markers will take a lot to revamp to FA5, this will at least have us working with all available icons in 4.7.